### PR TITLE
feat: Show URLs for today and tomorrow

### DIFF
--- a/index.php
+++ b/index.php
@@ -62,8 +62,12 @@ if (empty($requestUri)) {
 // Get the current date. For testing, we can override this.
 // $today = '2025-08-12';
 $today = date('Y-m-d');
+$tomorrow = date('Y-m-d', strtotime('+1 day'));
 
-$scheduledFiles = getScheduledFiles($today);
+$todaysFiles = getScheduledFiles($today);
+$tomorrowsFiles = getScheduledFiles($tomorrow);
+
+$scheduledFiles = array_merge($todaysFiles, $tomorrowsFiles);
 
 $isScheduled = false;
 $requestedFileDetails = null;


### PR DESCRIPTION
The script now fetches and displays scheduled content for both the current day and the following day. This is achieved by getting the schedules for both days and merging them before processing the request.