### PR TITLE
fix: Handle URLs with or without category in the path

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,5 +6,5 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-l
 
-# Rewrite requests for category1, category2, and imagenes to index.php
-RewriteRule ^(category1|category2|imagenes)/(.*)$ index.php?uri=$1/$2 [L,QSA]
+# Rewrite all requests to index.php
+RewriteRule ^(.*)$ index.php?uri=$1 [L,QSA]

--- a/index.php
+++ b/index.php
@@ -71,27 +71,29 @@ $scheduledFiles = array_merge($todaysFiles, $tomorrowsFiles);
 
 $isScheduled = false;
 $requestedFileDetails = null;
+$category = null;
+$filename = basename($requestUri);
 
-// The request URI will be something like 'category1/some-file.html'
-$parts = explode('/', $requestUri);
-$category = $parts[0];
-$filename = $parts[1];
-
-foreach ($scheduledFiles as $file) {
-    if ($file['html_name'] === $filename && 'category' . $file['category'] === $category) {
-        $isScheduled = true;
-        $requestedFileDetails = $file;
-        break;
-    }
-}
-
-// Also check for images. The URI for an image will be like 'imagenes/some-file.jpg'
-if ($category === 'imagenes') {
+if (strpos($requestUri, 'imagenes/') === 0) {
+    $category = 'imagenes';
     $htmlFilename = pathinfo($filename, PATHINFO_FILENAME) . '.html';
     foreach ($scheduledFiles as $file) {
         if ($file['html_name'] === $htmlFilename) {
             $isScheduled = true;
             break;
+        }
+    }
+} else {
+    // It's a request for an HTML file.
+    $fileExtension = pathinfo($filename, PATHINFO_EXTENSION);
+    if ($fileExtension === 'html') {
+        foreach ($scheduledFiles as $file) {
+            if ($file['html_name'] === $filename) {
+                $isScheduled = true;
+                $requestedFileDetails = $file;
+                $category = 'category' . $file['category'];
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
This change makes the URL handling more robust. The script can now handle URLs that include the category in the path (e.g., /category2/file.html) as well as URLs that do not (e.g., /file.html). This is achieved by updating the .htaccess file to rewrite all relevant requests to index.php and modifying the PHP script to determine the file's category from the schedule data rather than relying on the URL structure.